### PR TITLE
Add product-manager-skills to Collaboration & Project Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **linear-cli-skill** | A skill teaching Claude how to use linear-CLI as an alternative to Linear MCP | [Source](https://github.com/Valian/linear-cli-skill) |
 | **review-implementing** | Evaluate code implementation plans and align with specs | [Source](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) |
 | **test-fixing** | Detect failing tests and propose patches or fixes | [Source](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) |
+| **product-manager-skills** | Senior PM agent with 6 knowledge domains, 12 templates, 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching, and AI product craft | [Source](https://github.com/Digidai/product-manager-skills) |
 
 
 ---


### PR DESCRIPTION
## Summary

- Adds **product-manager-skills** by [Digidai](https://github.com/Digidai) to the Collaboration & Project Management category
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks
- Covers product discovery, strategy, delivery, 32 SaaS metrics with formulas, PM career coaching (IC to CPO), and AI product craft
- Pure Markdown, zero scripts — works with Claude Code via `clawhub install product-manager-skills`

**Source:** https://github.com/Digidai/product-manager-skills