### PR TITLE
Add Agent Cards skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **move-code-quality-skill** | Analyzes Move language packages against the official Move Book Code Quality Checklist | [Source](https://github.com/1NickPappas/move-code-quality-skill) |
 | **claude-code-terminal-title** | Gives each Claude Code terminal window a dynamic title describing the work being done | [Source](https://github.com/bluzername/claude-code-terminal-title) |
 | **audit-website** | Cli website auditing tool for seo, performance, security and 140+ other rules | [Source](https://github.com/squirrelscan/skills/tree/main) |
+| **agent-cards-skill** | Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools. | [Source](https://github.com/agent-cards/skill) |
 
 
 ---


### PR DESCRIPTION
## Summary

Adds [agent-cards/skill](https://github.com/agent-cards/skill) to the list.

**Agent Cards** lets AI agents create and spend prepaid virtual Visa cards — each with a fixed budget, real card credentials, and full MCP integration. The skill teaches agents how to:

- **Create cards** — set a dollar amount, complete Stripe Checkout, get a card back
- **Check balances** — quick balance lookup
- **View card credentials** — full card number, CVV, expiry (with email approval)
- **Close cards** — permanent closure with user confirmation
- **Get support** — open and manage support conversations

Works with Claude Code, Codex, and any agent that supports SKILL.md.

- **Repo:** https://github.com/agent-cards/skill
- **Product:** https://agentcard.sh
- **Install:** `npx skills add agent-cards/skill`