### PR TITLE
Add avoid-ai-writing to Writing & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **writing-skills** | Enhance instructional and technical writing quality | [Source](https://github.com/obra/superpowers/tree/main/skills/writing-skills) |
 | **brainstorming** | Facilitate creative idea generation sessions | [Source](https://github.com/obra/superpowers/tree/main/skills/brainstorming) |
 | **family-history-research** | Provides assistance with planning family history and genealogy research projects | [Source](https://github.com/emaynard/claude-family-history-research-skill) |
+| **avoid-ai-writing** | Audit and rewrite content to remove 21 categories of AI writing patterns with a 43-entry replacement table | [Source](https://github.com/conorbronsdon/avoid-ai-writing) |
 
 ---
 


### PR DESCRIPTION
Adds avoid-ai-writing, a Claude Code skill that detects and fixes 21 categories of AI writing patterns (em dash overuse, copula avoidance, significance inflation, synonym cycling, filler phrases, chatbot artifacts, etc.). Includes a 43-entry word/phrase replacement table with specific alternatives and a structured four-section output with second-pass audit. MIT licensed. https://github.com/conorbronsdon/avoid-ai-writing