### PR TITLE
Add senior-by-default skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This repository gathers and organizes all publicly available Claude Skills, incl
 
 ## 📈 Overview
 
-**226 skills** across **13 categories**:
+**227 skills** across **13 categories**:
 
 | Category | Skills |
 |----------|--------|
-| 💻 Development & Code Tools | 74 |
+| 💻 Development & Code Tools | 75 |
 | 📣 Marketing & SEO | 20 |
 | 📝 Writing & Research | 20 |
 | 🤝 Collaboration & Project Management | 19 |
@@ -189,6 +189,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **context-engineering-kit** | Advanced context engineering with multi-agent patterns, reflexion loops, and domain-driven development | [Source](https://github.com/NeoLabHQ/context-engineering-kit) |
 | **compound-engineering-plugin** | Pragmatic engineering plugin with ideation, planning, execution, multi-agent review, and knowledge compounding | [Source](https://github.com/EveryInc/compound-engineering-plugin) |
 | **vscode-extension-builder** | Scaffolds, compiles, packages, and installs a working VS Code extension end-to-end from a single request — command extensions, color themes, and snippet packs | [Source](https://github.com/SuryaPrakashPandurangi/vscode-extension-builder) |
+| **do** (senior-by-default) | Multi-actor implementation pipeline that routes a plain-language task by complexity: Opus plans and reviews, Sonnet implements, Haiku handles trivial mechanical edits, with gated review (PR size, dep-vuln, i18n, contract, zero-downtime migration audit) before a PR is opened. Runs only on an explicit `/do` invocation; commits, pushes, and merges stay behind confirmation gates | [Source](https://github.com/mitiay7/senior-by-default/blob/main/skills/do/SKILL.md) |
 
 ---
 


### PR DESCRIPTION
Adding `senior-by-default` to **💻 Development & Code Tools**.

**What it is.** A multi-actor `/do` pipeline skill for Claude Code. You write a task in plain language ("add user avatars to settings page", "create a /health endpoint that pings the DB"), and the skill translates it into the language of your specific project — stack, conventions, existing patterns — and ships it as a senior engineer would.

Under the hood: Opus plans and reviews, Sonnet implements, Haiku handles trivial mechanical changes. Three actors with hard role boundaries (Opus never writes code unless explicitly flagged with `--implementer=opus`; Haiku never makes logic decisions). Quality gates are pass/fail against acceptance criteria, not subjective 1-10 reviews.

**Highlights:**
- **Self-review calibration metric** — Sonnet declares `claimed_status: ready` before Phase 3 review; the outcome is compared and `false_positive` rate is logged per task.
- **Zero-downtime migration audit** — `DROP COLUMN` / `RENAME` / `NOT NULL`-without-default get blocked with the expand-contract pattern.
- **Stack-aware** — detects Go / TS / Rust / Python / Ruby / PHP / JVM / Dart / .NET / Deno / Elixir; scans monorepo subdirs (`apps/`, `services/`); detection cached per repo.
- **Tracker-agnostic** — GitHub `gh` by default, GitLab `glab`, or custom command templates for Linear/Jira/etc.

**Format.** Added one row to the existing markdown table at the end of "Development & Code Tools", matching surrounding style, and bumped the Overview counts (226 → 227, Development & Code Tools 74 → 75).

**Required info per CONTRIBUTING:**
- Name: `do` — the skill's own name in its frontmatter (`senior-by-default` is the plugin/repo name, kept in the row's parenthetical for discoverability)
- Description: see table row
- Category: 💻 Development & Code Tools
- Source: https://github.com/mitiay7/senior-by-default/blob/main/skills/do/SKILL.md (repo root: https://github.com/mitiay7/senior-by-default)
- License: MIT

Happy to adjust wording, category, or trim the description if needed.
