### PR TITLE
Add vscode-extension-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This repository gathers and organizes all publicly available Claude Skills, incl
 
 ## 📈 Overview
 
-**218 skills** across **13 categories**:
+**219 skills** across **13 categories**:
 
 | Category | Skills |
 |----------|--------|
-| 💻 Development & Code Tools | 72 |
+| 💻 Development & Code Tools | 73 |
 | 📣 Marketing & SEO | 20 |
 | 📝 Writing & Research | 20 |
 | 🤝 Collaboration & Project Management | 18 |
@@ -187,6 +187,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **claude-a11y-skill** | Comprehensive accessibility audits combining axe-core and eslint-plugin-jsx-a11y against WCAG 2.1 | [Source](https://github.com/airowe/claude-a11y-skill) |
 | **context-engineering-kit** | Advanced context engineering with multi-agent patterns, reflexion loops, and domain-driven development | [Source](https://github.com/NeoLabHQ/context-engineering-kit) |
 | **compound-engineering-plugin** | Pragmatic engineering plugin with ideation, planning, execution, multi-agent review, and knowledge compounding | [Source](https://github.com/EveryInc/compound-engineering-plugin) |
+| **vscode-extension-builder** | Scaffolds, compiles, packages, and installs a working VS Code extension end-to-end from a single request — command extensions, color themes, and snippet packs | [Source](https://github.com/SuryaPrakashPandurangi/vscode-extension-builder) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Name: `vscode-extension-builder`
- Description: Scaffolds, compiles, packages, and installs a working VS Code extension end-to-end from a single request — command extensions, color themes, and snippet packs.
- Category: Development & Code Tools
- Link to source: https://github.com/SuryaPrakashPandurangi/vscode-extension-builder

Adds one row to the Development & Code Tools table and bumps the corresponding skill counts (72 -> 73, 218 -> 219 total). No skill code is included in this PR - README only, per the repository's linking convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)