### PR TITLE
docs: add LinkedIn skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ This repository gathers and organizes all publicly available Claude Skills, incl
 
 ## 📈 Overview
 
-**220 skills** across **13 categories**:
+**222 skills** across **13 categories**:
 
 | Category | Skills |
 |----------|--------|
 | 💻 Development & Code Tools | 72 |
-| 📣 Marketing & SEO | 21 |
+| 📣 Marketing & SEO | 22 |
 | 📝 Writing & Research | 20 |
 | 🤝 Collaboration & Project Management | 18 |
-| ⚙️ Utility & Automation | 25 |
+| ⚙️ Utility & Automation | 26 |
 | 🔐 Security & Testing | 13 |
 | 📚 Learning & Knowledge | 15 |
 | 🎨 Creative & Design | 9 |
@@ -326,6 +326,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **analytics-tracking** | Analytics setup and measurement implementation | [Source](https://github.com/coreyhaines31/marketingskills/tree/main/skills/analytics) |
 | **marketing-psychology** | Behavioral science application to marketing copy and UX | [Source](https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-psychology) |
 | **vibe-prospecting** | B2B company and contact prospecting with structured enrichment, events, and sample-first retrieval | [Source](https://github.com/explorium-ai/vibeprospecting-plugin/tree/main/skills/vibe-prospecting) |
+| **linkedin-growth** | Managed LinkedIn network-growth pipeline for qualified leads | [Source](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth) |
 | **seo-audit-full** | Deep technical and content SEO auditing workflow for comprehensive site/page analysis | [Source](https://github.com/JeffLi1993/seo-audit-skill/tree/main/seo-audit-full) |
 
 ---
@@ -384,6 +385,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **replicate** | Official Replicate skill for discovering, comparing, and running AI models via API | [Source](https://github.com/replicate/skills) |
 | **agentsys** | 36 workflow automation skills for profiling, code review, AI consultation, release management, and drift analysis | [Source](https://github.com/avifenesh/agentsys) |
 | **better-i18n** | Official i18n skill for internationalization best practices, translation workflows, and localization automation | [Source](https://github.com/better-i18n/skills) |
+| **linkedin** | General-purpose LinkedIn automation for AI agents | [Source](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin) |
 | **migrate-to-shoehorn** | Migrate test assertions to @total-typescript/shoehorn patterns | [Source](https://github.com/mattpocock/skills/tree/main/skills/misc/migrate-to-shoehorn) |
 | **scaffold-exercises** | Scaffold structured exercise directories with sections, problems, solutions, and explainers | [Source](https://github.com/mattpocock/skills/tree/main/skills/misc/scaffold-exercises) |
 | **edit-article** | Assist with article editing and refinement workflows | [Source](https://github.com/mattpocock/skills/tree/main/skills/personal/edit-article) |


### PR DESCRIPTION
Ports the owner-approved Linked API catalogue entries from #30 onto current `main` with updated counts.

Closes #30.