### PR TITLE
Add danshari-skill (断舍离.skill) to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you use skills across more than one coding agent, [Skill Manager](https://abu
 
 ## 📈 Overview
 
-**227 skills** across **13 categories**:
+**228 skills** across **13 categories**:
 
 | Category | Skills |
 |----------|--------|
@@ -27,7 +27,7 @@ If you use skills across more than one coding agent, [Skill Manager](https://abu
 | 📣 Marketing & SEO | 21 |
 | 📝 Writing & Research | 20 |
 | 🤝 Collaboration & Project Management | 19 |
-| ⚙️ Utility & Automation | 27 |
+| ⚙️ Utility & Automation | 28 |
 | 🔐 Security & Testing | 15 |
 | 📚 Learning & Knowledge | 14 |
 | 🎨 Creative & Design | 9 |
@@ -407,6 +407,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **wizard** | Generate an interactive bash wizard that walks a human through a manual procedure — opening URLs, capturing values, confirming each step | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/wizard) |
 | **setup-ts-deep-modules** | Wire dependency-cruiser into a TypeScript repo so each package is a deep module with a small public surface | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/setup-ts-deep-modules) |
 | **claude-handoff** | Hand the current conversation off to a fresh background agent that picks up the work immediately | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/claude-handoff) |
+| **danshari-skill (断舍离.skill)** | Audits every skill you have installed and archives the ones your current model, harness, or MCP servers already cover — three-way triage, blind-test evidence before any removal, and one-command restore instead of `rm` | [Source](https://github.com/swaylq/danshari-skill) |
 
 ---
 


### PR DESCRIPTION
Adds [**danshari-skill (断舍离.skill)**](https://github.com/swaylq/danshari-skill) — MIT, zero dependencies, bilingual README (中文 / English).

**What it does.** The ecosystem is all addition — awesome lists collect thousands of skills, single repos ship three hundred. This one does subtraction: it audits every skill an agent has installed against the *current* model, harness, and MCP servers, and archives the ones that no longer earn their per-turn description-token cost.

- **Three-way triage** — *capability* skills (the ones model upgrades obsolete), *environment* skills (obsoleted by harness features and MCP servers), *knowledge* skills (private facts — protected, never removed).
- **Blind test before removal** — a capability skill is never cut on a hunch. A subagent that does *not* load it attempts the skill's most typical task first; only matching quality justifies removal.
- **Never `rm`** — every removal is a move into an archive directory with a MANIFEST and `tools/archive.sh --restore <name>`. Private facts buried in an obsolete skill are extracted before it is archived.
- Ships an end-to-end [demo audit](https://github.com/swaylq/danshari-skill/blob/main/examples/2026-08-17-demo/report.md): 12 skills → 5, description tax 2,160 → 735 tokens/turn (-66%), every verdict backed by evidence.

Install: `git clone https://github.com/swaylq/danshari-skill.git ~/.claude/skills/danshari-skill`

Happy to move it to a different category, shorten the description, or split the entry — just say the word.

---

Also bumped the Overview counts (227 → 228 total, Utility & Automation 27 → 28) to keep them consistent.
