### PR TITLE
Add sijiao-skill (私教.skill) to Utility & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you use skills across more than one coding agent, [Skill Manager](https://abu
 
 ## 📈 Overview
 
-**227 skills** across **13 categories**:
+**228 skills** across **13 categories**:
 
 | Category | Skills |
 |----------|--------|
@@ -27,7 +27,7 @@ If you use skills across more than one coding agent, [Skill Manager](https://abu
 | 📣 Marketing & SEO | 21 |
 | 📝 Writing & Research | 20 |
 | 🤝 Collaboration & Project Management | 19 |
-| ⚙️ Utility & Automation | 27 |
+| ⚙️ Utility & Automation | 28 |
 | 🔐 Security & Testing | 15 |
 | 📚 Learning & Knowledge | 14 |
 | 🎨 Creative & Design | 9 |
@@ -407,6 +407,7 @@ Official Skills are created by Anthropic and auto-invoked when needed. You can a
 | **wizard** | Generate an interactive bash wizard that walks a human through a manual procedure — opening URLs, capturing values, confirming each step | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/wizard) |
 | **setup-ts-deep-modules** | Wire dependency-cruiser into a TypeScript repo so each package is a deep module with a small public surface | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/setup-ts-deep-modules) |
 | **claude-handoff** | Hand the current conversation off to a fresh background agent that picks up the work immediately | [Source](https://github.com/mattpocock/skills/tree/main/skills/in-progress/claude-handoff) |
+| **sijiao-skill (私教.skill)** | Distils any skill you want to learn into a stateful tutor — it remembers where you are, sets and grades exercises at your level, and schedules spaced review, with the ceiling honestly capped at competent | [Source](https://github.com/swaylq/sijiao-skill) |
 
 ---
 


### PR DESCRIPTION
Adds [**sijiao-skill (私教.skill)**](https://github.com/swaylq/sijiao-skill) — MIT, zero dependencies, bilingual README, [site](https://swaylq.github.io/sijiao-skill/).

**What it does.** Name a skill you want to learn. It runs eight parallel research tracks (knowledge map, canonical sources, expert paths, deliberate practice, common sticking points, assessment, feedback communities, motivation), distils a learning-science curriculum, and writes a **stateful tutor** — a self-contained directory with a prerequisite-ordered curriculum, the tutor's own SKILL.md, and a private learner-state file.

The difference from "ask an LLM for a study plan" is state: it remembers which module you're on, what you got wrong, and schedules SM-2 spaced review — every session clears due items before new material.

**Quality gate** (any single failure blocks generation):
- prerequisite graph must be acyclic, and every "learn A before B" traces to a source
- every module needs a *gradeable* exercise, never "read this book"
- "you've got it" must be behavioural ("can do X unaided"), not "understands X"
- canonical resources need 3 independent recommendations; SEO listicles rejected
- the ceiling is capped at Dreyfus *competent* — claiming to make you an expert is disqualifying

Ships **6 end-to-end samples** (Rust, linear algebra, English reading, fat loss, skincare, strength training — 79 modules total), all engine-validated, and 35 green tests over the tooling engine. The three physiological ones are there to show how the framework downgrades honestly when AI can't actually judge the work.

Happy to move it to a different category or trim the description.

---

Note: I also have PR #41 open adding danshari-skill, which bumps the same Overview counts 227 → 228. If you merge both, the totals want to land at **229** / Utility & Automation **29** — happy to rebase whichever lands second.
